### PR TITLE
Allow literal string argument that starts with a "#".

### DIFF
--- a/mako/ext/babelplugin.py
+++ b/mako/ext/babelplugin.py
@@ -76,9 +76,12 @@ def extract_nodes(nodes, keywords, comment_tags, options):
         elif isinstance(node, parsetree.PageTag):
             code = node.body_decl.code
         elif isinstance(node, parsetree.CallNamespaceTag):
-            attribs = ', '.join(['%s=%s' % (key, val)
-                                 for key, val in node.attributes.items()])
-            code = '{%s}' % attribs
+            attribs = []
+            for key, val in node.attributes.items():
+                if not val.startswith('${'):
+                    val = "'%s'" % val
+                attribs.append('%s=%s' % (key, val))
+            code = '{%s}' % ', '.join(attribs)
             child_nodes = node.nodes
         elif isinstance(node, parsetree.ControlLine):
             if node.isend:

--- a/test/templates/gettext.mako
+++ b/test/templates/gettext.mako
@@ -80,7 +80,7 @@ top = gettext('Begin')
 
 <%def name="panel()">
 
-${_(u'foo')} <%self:block_tpl title="123", name="_(u'baz')">
+${_(u'foo')} <%self:block_tpl title="#123", name="_(u'baz')">
 
 ${_(u'bar')}
 

--- a/test/test_babelplugin.py
+++ b/test/test_babelplugin.py
@@ -37,7 +37,6 @@ class ExtractMakoTestCase(TemplateTest):
             (71, '_', 'P.S. byebye', []),
             (77, '_', 'Top', []),
             (83, '_', 'foo', []),
-            (83, '_', 'baz', []),
             (85, '_', 'bar', [])
              ]
         self.assertEqual(expected, messages)


### PR DESCRIPTION
Without this change, when running setup.py extract_messages, we would get
error:

```
TokenError: ('EOF in multi-line statement', (2, 0))
```

Looking at the unit test, it seems like a literal string argument in the form
of "_('xxx')" is supposed to be picked up by Babel. However, that contradicts
with the documentation, which states:

> When using tags, the values of the arguments are taken as literal strings by
> default. To embed Python expressions as arguments, use the embedded
> expression format

So, as a side effect of this commit, the convenience of "_('xxx')" has been
removed. Probably can add it back if necessary for backward compatibility.
