### PR TITLE
simplify

### DIFF
--- a/mako/ext/babelplugin.py
+++ b/mako/ext/babelplugin.py
@@ -76,15 +76,7 @@ def extract_nodes(nodes, keywords, comment_tags, options):
         elif isinstance(node, parsetree.PageTag):
             code = node.body_decl.code
         elif isinstance(node, parsetree.CallNamespaceTag):
-            attribs = ', '.join(['%s=%s' % (
-                                    key,
-                                    repr(val)
-                                    if not val.startswith('${')
-                                    else val
-                                )
-                                    for key, val in node.attributes.items()])
-
-            code = '{%s}' % attribs
+            code = node.expression
             child_nodes = node.nodes
         elif isinstance(node, parsetree.ControlLine):
             if node.isend:


### PR DESCRIPTION
I'm surprised this ever worked as it was, apparently extract_python (the tokenize module) was fine with parsing invalid Python code that this generated, crap like: {foo='bar'}
