### PR TITLE
_ast_util.py added visit_NameConstant to SourceGen

### DIFF
--- a/mako/_ast_util.py
+++ b/mako/_ast_util.py
@@ -659,6 +659,9 @@ class SourceGenerator(NodeVisitor):
     def visit_Name(self, node):
         self.write(node.id)
 
+    def visit_NameConstant(self, node):
+        self.write(str(node.value))
+
     def visit_arg(self, node):
         self.write(node.arg)
 


### PR DESCRIPTION
SourceGenerator didn't work with python3.4 alpha,
`None` Is now a NameConstant rather than a Name in ast
the new method deals with converting it to a string
