### PR TITLE
added arg_stringname function to _ast_util.py

### DIFF
--- a/mako/_ast_util.py
+++ b/mako/_ast_util.py
@@ -78,6 +78,15 @@ ALL_SYMBOLS.update(BINOP_SYMBOLS)
 ALL_SYMBOLS.update(CMPOP_SYMBOLS)
 ALL_SYMBOLS.update(UNARYOP_SYMBOLS)
 
+def arg_stringname(func_arg):
+    """Gets the string name of a kwarg or vararg
+    In Python3.4 a function's args are
+    of _ast.arg type not _ast.name
+    """
+    if hasattr(func_arg, 'arg'):
+        return func_arg.arg
+    else:
+        return str(func_arg)
 
 def parse(expr, filename='<unknown>', mode='exec'):
     """Parse an expression into an AST node."""
@@ -403,10 +412,10 @@ class SourceGenerator(NodeVisitor):
                 self.visit(default)
         if node.vararg is not None:
             write_comma()
-            self.write('*' + node.vararg)
+            self.write('*' + arg_stringname(node.vararg))
         if node.kwarg is not None:
             write_comma()
-            self.write('**' + node.kwarg)
+            self.write('**' + arg_stringname(node.kwarg))
 
     def decorators(self, node):
         for decorator in node.decorator_list:

--- a/mako/ast.py
+++ b/mako/ast.py
@@ -8,6 +8,7 @@
 code, as well as generating Python from AST nodes"""
 
 from mako import exceptions, pyparser, compat
+from mako._ast_util import arg_stringname
 import re
 
 class PythonCode(object):
@@ -126,10 +127,10 @@ class FunctionDecl(object):
         for arg in argnames:
             default = None
             if kwargs:
-                arg = "**" + arg
+                arg = "**" + arg_stringname(arg)
                 kwargs = False
             elif varargs:
-                arg = "*" + arg
+                arg = "*" + arg_stringname(arg)
                 varargs = False
             else:
                 default = len(defaults) and defaults.pop() or None

--- a/mako/pyparser.py
+++ b/mako/pyparser.py
@@ -11,6 +11,7 @@ module is used.
 """
 
 from mako import exceptions, util, compat
+from mako._ast_util import arg_stringname
 from mako.compat import StringIO
 import operator
 
@@ -215,14 +216,13 @@ if _ast:
             self.listener.funcname = node.name
             argnames = [arg_id(arg) for arg in node.args.args]
             if node.args.vararg:
-                argnames.append(node.args.vararg)
+                argnames.append(arg_stringname(node.args.vararg))
             if node.args.kwarg:
-                argnames.append(node.args.kwarg)
+                argnames.append(arg_stringname(node.args.kwarg))
             self.listener.argnames = argnames
             self.listener.defaults = node.args.defaults  # ast
             self.listener.varargs = node.args.vararg
             self.listener.kwargs = node.args.kwarg
-
 
     class ExpressionGenerator(object):
 


### PR DESCRIPTION
This is to be compatible with python3.4 where kwarg and vararg
objects are _ast.arg as opposed to Name objects in earlier versions.
The _ast.arg object cannot be implicitly converted to a string. This
lead to 4 errors in the test suite.

As of this commit all tests pass under python3.4a2
