### PR TITLE
Improved handling of translator comments in Babel plugin

### DIFF
--- a/test/templates/gettext.mako
+++ b/test/templates/gettext.mako
@@ -88,3 +88,12 @@ ${_(u'bar')}
 
 </%def>
 
+## TRANSLATOR: <p> tag is ok?
+<p>${_("Inside a p tag")}</p>
+
+## TRANSLATOR: also this
+<p>${even_with_other_code_first()} - ${_("Later in a p tag")}</p>
+
+## TRANSLATOR: we still ignore comments too far from the string
+
+<p>${_("No action at a distance.")}</p>

--- a/test/test_babelplugin.py
+++ b/test/test_babelplugin.py
@@ -40,7 +40,10 @@ class ExtractMakoTestCase(TemplateTest):
             (77, '_', 'Top', []),
             (83, '_', 'foo', []),
             (83, '_', 'hoho', []),
-            (85, '_', 'bar', [])
+             (85, '_', 'bar', []),
+             (92, '_', 'Inside a p tag', ['TRANSLATOR: <p> tag is ok?']),
+             (95, '_', 'Later in a p tag', ['TRANSLATOR: also this']),
+             (99, '_', 'No action at a distance.', []),
              ]
         self.assertEqual(expected, messages)
 


### PR DESCRIPTION
There's no reason an intervening node should clear the translator
comments.  There's already logic that discards the comments if they
occurred too far away from the harvested string.  This way we can write
more natural templates and still have the translator comments that
provide the best translated text.

http://www.makotemplates.org/trac/ticket/225
