### PR TITLE
Add more source comments to the code generator

### DIFF
--- a/mako/codegen.py
+++ b/mako/codegen.py
@@ -251,6 +251,7 @@ class _GenerateRenderMethod(object):
 
         this could be the main render() method or that of a top-level def."""
 
+        self.printer.writeline("# BOILERPLATE")
         if self.in_def:
             decorator = node.decorator
             if decorator:
@@ -305,6 +306,7 @@ class _GenerateRenderMethod(object):
     def write_inherit(self, node):
         """write the module-level inheritance-determination callable."""
 
+        self.printer.writeline("# BOILERPLATE")
         self.printer.writelines(
             "def _mako_inherit(template, context):",
                 "_mako_generate_namespaces(context)",
@@ -315,6 +317,7 @@ class _GenerateRenderMethod(object):
 
     def write_namespaces(self, namespaces):
         """write the module-level namespace-generating callable."""
+        self.printer.writeline("# BOILERPLATE")
         self.printer.writelines(
             "def _mako_get_namespace(context, name):",
                 "try:",
@@ -606,6 +609,7 @@ class _GenerateRenderMethod(object):
         writes code to retrieve captured content, apply filters, send proper
         return value."""
 
+        self.printer.writeline("# BOILERPLATE")
         if not buffered and not cached and not filtered:
             self.printer.writeline("return ''")
             if callstack:
@@ -861,6 +865,7 @@ class _GenerateRenderMethod(object):
         pass
 
     def visitBlockTag(self, node):
+        self.printer.writeline("# BOILERPLATE")
         if node.is_anonymous:
             self.printer.writeline("%s()" % node.funcname)
         else:
@@ -930,6 +935,7 @@ class _GenerateRenderMethod(object):
             n.accept_visitor(self)
         self.identifier_stack.pop()
 
+        self.printer.writeline("# BOILERPLATE")
         self.write_def_finish(node, buffered, False, False, callstack=False)
         self.printer.writelines(
             None,


### PR DESCRIPTION
I'm experimenting with adding Mako support to coverage.py.  In order to
fully parse the generated Python files to correlate generated lines with
source lines, I've added more comment output to identify the lines that
aren't associated with any source line.

This is probably not all the places that need to be commented, but seems
to work well for the templates I'm using. If you have a better way to do
this, or a different way to accomplish the same thing, I'm completely
open to other ideas.
