### PR TITLE
Double brace expression

### DIFF
--- a/mako/cmd.py
+++ b/mako/cmd.py
@@ -35,6 +35,8 @@ def cmdline(argv=None):
         "template is read from stdin, the value defaults to be "
         "the current directory, otherwise it defaults to be the "
         "parent directory of the file provided.")
+    parser.add_argument('--double-brace', action='store_true',
+                        help="Use {{ ... }} instead of ${ ... }")
     parser.add_argument('input', nargs='?', default='-')
 
     options = parser.parse_args(argv)
@@ -42,7 +44,8 @@ def cmdline(argv=None):
         lookup_dirs = options.template_dir or ["."]
         lookup = TemplateLookup(lookup_dirs)
         try:
-            template = Template(sys.stdin.read(), lookup=lookup)
+            template = Template(sys.stdin.read(), lookup=lookup,
+                                double_brace=options.double_brace)
         except:
             _exit()
     else:
@@ -52,7 +55,8 @@ def cmdline(argv=None):
         lookup_dirs = options.template_dir or [dirname(filename)]
         lookup = TemplateLookup(lookup_dirs)
         try:
-            template = Template(filename=filename, lookup=lookup)
+            template = Template(filename=filename, lookup=lookup,
+                                double_brace=options.double_brace)
         except:
             _exit()
 

--- a/mako/template.py
+++ b/mako/template.py
@@ -7,7 +7,7 @@
 """Provides the Template class, a facade for parsing, generating and executing
 template strings, as well as template runtime operations."""
 
-from mako.lexer import Lexer
+from mako.lexer import Lexer, LexerDoubleBrace
 from mako import runtime, util, exceptions, codegen, cache, compat
 import os
 import re
@@ -243,7 +243,8 @@ class Template(object):
                  future_imports=None,
                  enable_loop=True,
                  preprocessor=None,
-                 lexer_cls=None):
+                 lexer_cls=None,
+                 double_brace=False):
         if uri:
             self.module_id = re.sub(r'\W', "_", uri)
             self.uri = uri
@@ -295,6 +296,9 @@ class Template(object):
         self.imports = imports
         self.future_imports = future_imports
         self.preprocessor = preprocessor
+
+        if double_brace:
+            self.lexer_cls = LexerDoubleBrace
 
         if lexer_cls is not None:
             self.lexer_cls = lexer_cls

--- a/test/test_cmd.py
+++ b/test/test_cmd.py
@@ -29,7 +29,6 @@ class CmdTest(TemplateTest):
                         stderr.write.mock_calls[0][1][0]
             assert "Traceback" in stderr.write.mock_calls[0][1][0]
 
-
     def test_stdin_rt_err(self):
         with mock.patch("sys.stdin", mock.Mock(
                             read=mock.Mock(return_value="${q}"))):
@@ -70,3 +69,10 @@ class CmdTest(TemplateTest):
         with raises(SystemExit, "error: can't find fake.lalala"):
             cmdline(["--var", "x=5", "fake.lalala"])
 
+    def test_double_brace_stdin_success(self):
+        with self._capture_output_fixture() as stdout:
+            with mock.patch("sys.stdin", mock.Mock(
+                            read=mock.Mock(return_value="hello world {{x}}"))):
+                cmdline(["--double-brace", "--var", "x=5", "-"])
+
+        eq_(stdout.write.mock_calls[0][1][0], "hello world 5")

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -1358,3 +1358,12 @@ class FuturesTest(TemplateTest):
     def test_future_import(self):
         t = Template("${ x / y }", future_imports=["division"])
         assert result_lines(t.render(x=12, y=5)) == ["2.4"]
+
+
+class DoubleBraceTest(TemplateTest):
+    def test_double_brace(self):
+        template = Template("""
+            hello {{x}}, {} ${x} <%text>{{x}}</%text> {{y}} {} {y}, ${z} {{z}}
+""", double_brace=True)
+
+        assert flatten_result(template.render(x=5, y=10, z=7)) == "hello 5, {} ${x} {{x}} 10 {} {y}, ${z} 7"


### PR DESCRIPTION
I am using mako in shell scripts where the ${}-syntax is already in use by shell variables. So I have to use <%text>-blocks everywhere which is not convinient. This patch provides a way to specifiy an alternate expression syntax, namely double-braces: {{ ... }}.