### PR TITLE
correct template lookup on Windows:

### DIFF
--- a/mako/lookup.py
+++ b/mako/lookup.py
@@ -248,6 +248,9 @@ class TemplateLookup(TemplateCollection):
         except KeyError:
             u = re.sub(r'^\/+', '', uri)
             for dir in self.directories:
+                # make sure the path seperators are posix - os.altsep is empty
+                # on POSIX and cannot be used.
+                dir = dir.replace(os.path.sep, posixpath.sep)
                 srcfile = posixpath.normpath(posixpath.join(dir, u))
                 if os.path.isfile(srcfile):
                     return self._load(srcfile, uri)

--- a/test/ext/test_babelplugin.py
+++ b/test/ext/test_babelplugin.py
@@ -6,11 +6,10 @@ from mako import compat
 
 try:
     import babel.messages.extract as babel
-except:
-    babel = None
-
-if babel is not None:
     from mako.ext.babelplugin import extract
+    
+except ImportError:
+    babel = None
 
 
 def skip():


### PR DESCRIPTION
- posixpath.join does not handle windows paths very well.

Now all tests pass on py27 & py34 on windows.