### PR TITLE
modernize setup.py:

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,11 @@
 # any kind of "*" pulls in __init__.pyc files,
 # so all extensions are explicit.
 
-recursive-include doc *.html *.css *.txt *.js *.png *.py Makefile *.rst *.mako
-recursive-include examples *.py *.xml *.mako *.myt *.kid *.tmpl
+recursive-include doc *.css *.txt *.png *.py Makefile *.rst *.mako
+recursive-include examples *.py *.myt *.kid *.tmpl
 recursive-include test *.py *.html *.mako
 
-include README* LICENSE distribute_setup.py ez_setup.py CHANGES*
+include README* LICENSE CHANGES*
 
 prune doc/build/output
 

--- a/doc/build/conf.py
+++ b/doc/build/conf.py
@@ -193,7 +193,7 @@ html_domain_indices = False
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Makodoc'
+#htmlhelp_basename = 'Makodoc'
 
 #autoclass_content = 'both'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,11 +2,15 @@
 tag_build = dev
 
 
+[wheel]
+universal = 1
 
 [pytest]
 addopts= --tb native -v -r fxX
 python_files=test/*test_*.py
 
+[aliases]
+test=nosetests
 
 [upload]
 sign = 1

--- a/setup.py
+++ b/setup.py
@@ -1,75 +1,91 @@
+
+from sys import version_info as v
+if any([v < (2, 6), (3,) < v < (3, 3)]):
+    raise Exception("Unsupported Python version %d.%d. Requires Python >= 2.6 "
+                    "or >= 3.3." % v[:2])
+
 from setuptools import setup, find_packages
-import os
-import re
-import sys
+from os.path import abspath, dirname, join
 
-v = open(os.path.join(os.path.dirname(__file__), 'mako', '__init__.py'))
-VERSION = re.compile(r".*__version__ = '(.*?)'", re.S).match(v.read()).group(1)
-v.close()
+here = abspath(dirname(__file__))
 
-readme = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
+with open(join(here, 'mako', '__init__.py')) as fp:
+    _locals = {}
+    exec(fp.read(), None, _locals)
+    __version__ = _locals['__version__']
 
-if sys.version_info < (2, 6):
-    raise Exception("Mako requires Python 2.6 or higher.")
+with open(join(here, 'README.rst')) as r:
+    readme = r.read()
 
-markupsafe_installs = (
-            sys.version_info >= (2, 6) and sys.version_info < (3, 0)
-        ) or sys.version_info >= (3, 3)
+optional_requirements = [
+    'Beaker>=1.1', 
+    'babel', 
+    'lingua',
+    'pygments',
+]
 
-install_requires = []
+optional_tests_require = ['nose >= 0.11'] + optional_requirements
+tests_require = optional_tests_require[:]
+if v < (3,):
+    tests_require.append('mock')
 
-if markupsafe_installs:
-    install_requires.append('MarkupSafe>=0.9.2')
-
-try:
-    import argparse
-except ImportError:
-    install_requires.append('argparse')
-
-setup(name='Mako',
-      version=VERSION,
-      description="A super-fast templating language that borrows the \
+setup(
+    name='Mako',
+    version=__version__,
+    description="A super-fast templating language that borrows the \
  best ideas from the existing templating languages.",
-      long_description=readme,
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Environment :: Web Environment',
-          'Intended Audience :: Developers',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 3',
-          "Programming Language :: Python :: Implementation :: CPython",
-          "Programming Language :: Python :: Implementation :: PyPy",
-          'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-      ],
-      keywords='templates',
-      author='Mike Bayer',
-      author_email='mike@zzzcomputing.com',
-      url='http://www.makotemplates.org/',
-      license='MIT',
-      packages=find_packages('.', exclude=['examples*', 'test*']),
-      tests_require=['nose >= 0.11', 'mock'],
-      test_suite="nose.collector",
-      zip_safe=False,
-      install_requires=install_requires,
-      extras_require={},
-      entry_points="""
-      [python.templating.engines]
-      mako = mako.ext.turbogears:TGPlugin
+    long_description=readme,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Web Environment',
+        'Intended Audience :: Developers',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+    ],
+    keywords='templates',
+    author='Mike Bayer',
+    author_email='mike@zzzcomputing.com',
+    url='http://www.makotemplates.org/',
+    license='MIT',
+    packages=find_packages('.', exclude=['examples*', 'test*']),
+    tests_require=tests_require,
+    test_suite="nose.collector",
+    
+    zip_safe=False,
+    install_requires=[
+        'MarkupSafe>=0.9.2'
+    ],
+    extras_require={
+        ':python_version == "2.6"': [
+            'argparse'
+        ],
+        'optional': optional_requirements,
+        'test' : optional_tests_require,
+        'test:python_version == "2.6" or python_version == "2.7"': [
+            'mock'
+        ],
+    },
+    entry_points="""
+        [python.templating.engines]
+        mako = mako.ext.turbogears:TGPlugin
 
-      [pygments.lexers]
-      mako = mako.ext.pygmentplugin:MakoLexer
-      html+mako = mako.ext.pygmentplugin:MakoHtmlLexer
-      xml+mako = mako.ext.pygmentplugin:MakoXmlLexer
-      js+mako = mako.ext.pygmentplugin:MakoJavascriptLexer
-      css+mako = mako.ext.pygmentplugin:MakoCssLexer
+        [pygments.lexers]
+        mako = mako.ext.pygmentplugin:MakoLexer
+        html+mako = mako.ext.pygmentplugin:MakoHtmlLexer
+        xml+mako = mako.ext.pygmentplugin:MakoXmlLexer
+        js+mako = mako.ext.pygmentplugin:MakoJavascriptLexer
+        css+mako = mako.ext.pygmentplugin:MakoCssLexer
 
-      [babel.extractors]
-      mako = mako.ext.babelplugin:extract
+        [babel.extractors]
+        mako = mako.ext.babelplugin:extract
 
-      [lingua.extractors]
-      mako = mako.ext.linguaplugin:LinguaMakoExtractor
+        [lingua.extractors]
+        mako = mako.ext.linguaplugin:LinguaMakoExtractor
 
-      [console_scripts]
-      mako-render = mako.cmd:cmdline
-      """
+        [console_scripts]
+        mako-render = mako.cmd:cmdline
+        """
 )


### PR DESCRIPTION
- use environment markers - re-enabled universal wheels
- use setuptools_scm for version management (requires semantic version tags [1.0.2]
- stop supporting python 3 < 3.3
- normalize htmlhelp doc name
- remove dead entries from MANIFEST.in
