### PR TITLE
appveyor!

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,20 @@
 Mako Templates for Python
 =========================
 
+:Version: |version|
+:Travis CI: |travis|
+:Appveyor: |appveyor|
+
+.. |version| image:: https://img.shields.io/pypi/v/Mako.png
+        :target: https://pypi.python.org/pypi/Mako
+
+.. |travis| image:: https://img.shields.io/travis/zzzeek/mako.png
+        :target: https://travis-ci.org/zzzeek/mako
+
+.. |appveyor| image:: https://img.shields.io/appveyor/ci/zzzeek/mako.png
+        :target: https://ci.appveyor.com/project/zzzeek/mako/branch/master
+
+     
 Mako is a template library written in Python. It provides a familiar, non-XML 
 syntax which compiles into Python modules for maximum performance. Mako's 
 syntax and API borrows from the best ideas of many others, including Django

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27"
+      TOX_ENV: "py27"
+      
+    - PYTHON: "C:\\Python27-x64"
+      TOX_ENV: "py27"
+
+    - PYTHON: "C:\\Python33"
+      TOX_ENV: "py33"
+
+    - PYTHON: "C:\\Python33-x64"
+      TOX_ENV: "py33"
+
+    - PYTHON: "C:\\Python34"
+      TOX_ENV: "py34"
+
+    - PYTHON: "C:\\Python34-x64"
+      TOX_ENV: "py34"
+
+    - PYTHON: "C:\\Python35"
+      TOX_ENV: "py35"
+
+    - PYTHON: "C:\\Python35-x64"
+      TOX_ENV: "py35"
+
+init:
+  - "echo %PYTHON%"
+
+install:
+  - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"       
+  - python --version
+  - python -m pip install -U pip
+  - python -m pip install -U setuptools wheel virtualenv
+  - python -m pip install -U tox
+  
+  - ECHO "List Environemnt"
+  - python -m pip list --format=columns
+
+build: false  # Not a C# project, build stuff at the test step instead.
+
+test_script:
+  - python -m tox -e %TOX_ENV%"


### PR DESCRIPTION
needs an account at www.appveyor.com.

Babel on python 3.x is broken due to packaging error - mitsuhiko/babel#174
