### PR TITLE
Update docs link in README; old one was 403ing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Python is a great scripting language. Don't reinvent the wheel...your templates 
 Documentation
 ==============
 
-See documentation for Mako at http://www.makotemplates.org/docs/
+See documentation for Mako at http://docs.makotemplates.org/en/latest/
 
 License
 ========


### PR DESCRIPTION
[The old link](http://www.makotemplates.org/docs/) was a 403, it looks like the docs have moved. This link also exists on the main project homepage - I can't find the place to change that, it must not be in this repo.