### PR TITLE
Use sys.stdout.write instead of print in cmdline

### DIFF
--- a/mako/cmd.py
+++ b/mako/cmd.py
@@ -58,7 +58,7 @@ def cmdline(argv=None):
 
     kw = dict([varsplit(var) for var in options.var])
     try:
-        print(template.render(**kw))
+        sys.stdout.write(template.render(**kw))
     except:
         _exit()
 


### PR DESCRIPTION
The `print` function adds an unwanted `\n` char.