### PR TITLE
Do not display 'usage' twice

### DIFF
--- a/mako/cmd.py
+++ b/mako/cmd.py
@@ -24,7 +24,7 @@ def _exit():
 
 def cmdline(argv=None):
 
-    parser = ArgumentParser("usage: %prog [FILENAME]")
+    parser = ArgumentParser()
     parser.add_argument(
         "--var", default=[], action="append",
         help="variable (can be used multiple times, use name=value)")


### PR DESCRIPTION
Fixes https://bitbucket.org/zzzeek/mako/issues/270/help-usage-is-displayed-twice.

# Before

```
⌂76% [hugo:/private/tmp/mako] master(+1/-1) ± mako-render --help
usage: %prog [FILENAME] [-h] [--var VAR] [--template-dir TEMPLATE_DIR] [input]

positional arguments:
  input

optional arguments:
  -h, --help            show this help message and exit
  --var VAR             variable (can be used multiple times, use name=value)
  --template-dir TEMPLATE_DIR
                        Directory to use for template lookup (multiple
                        directories may be provided). If not given then if the
                        template is read from stdin, the value defaults to be
                        the current directory, otherwise it defaults to be the
                        parent directory of the file provided.
```

# After

```
⌂67% [hugo:/private/tmp/mako] fix-double-usage 2s ± mako-render --help
usage: mako-render [FILENAME] [-h] [--var VAR] [--template-dir TEMPLATE_DIR]
                              [input]

positional arguments:
  input

optional arguments:
  -h, --help            show this help message and exit
  --var VAR             variable (can be used multiple times, use name=value)
  --template-dir TEMPLATE_DIR
                        Directory to use for template lookup (multiple
                        directories may be provided). If not given then if the
                        template is read from stdin, the value defaults to be
                        the current directory, otherwise it defaults to be the
                        parent directory of the file provided.
```