### PR TITLE
Test on Python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: python
-python: 2.7
-env:
-  - TOX_ENV=py36
-  - TOX_ENV=py35
-  - TOX_ENV=py34
-  - TOX_ENV=py33
-  - TOX_ENV=py27
-  - TOX_ENV=py26
+python:
+  - "3.6"
+  - "3.5"
+  - "3.4"
+  - "3.3"
+  - "2.7"
+  - "2.6"
 install:
-  - python -m pip install -U tox
+  - pip install -U tox-travis
 script:
-  - python -m tox -e $TOX_ENV
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python: 2.7
 env:
+  - TOX_ENV=py36
+  - TOX_ENV=py35
   - TOX_ENV=py34
   - TOX_ENV=py33
   - TOX_ENV=py27

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
 minversion=1.8.dev1
-envlist = py{26,27,34,35}
+envlist = py{26,27,34,35,36}
 
 [testenv]
 cov_args=--cov=mako --cov-report term --cov-report xml


### PR DESCRIPTION
And use tox-travis to avoid `InterpreterNotFound`.

* Example failure with latest master: https://travis-ci.org/hugovk/mako/builds/329201841
* Example failure with first commit: https://travis-ci.org/hugovk/mako/builds/329216920
* Example pass with all commits: https://travis-ci.org/hugovk/mako/builds/329219701