### PR TITLE
Remove redundant Python<2.6 code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: python
-python: 2.7
-env:
-  - TOX_ENV=py36
-  - TOX_ENV=py35
-  - TOX_ENV=py34
-  - TOX_ENV=py33
-  - TOX_ENV=py27
-  - TOX_ENV=py26
+python:
+  - "3.6"
+  - "3.5"
+  - "3.4"
+  - "3.3"
+  - "2.7"
+  - "2.6"
 install:
-  - python -m pip install -U tox
+  - pip install -U tox-travis
 script:
-  - python -m tox -e $TOX_ENV
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python: 2.7
 env:
+  - TOX_ENV=py36
+  - TOX_ENV=py35
   - TOX_ENV=py34
   - TOX_ENV=py33
   - TOX_ENV=py27

--- a/mako/compat.py
+++ b/mako/compat.py
@@ -4,7 +4,6 @@ import time
 py3k = sys.version_info >= (3, 0)
 py33 = sys.version_info >= (3, 3)
 py2k = sys.version_info < (3,)
-py26 = sys.version_info >= (2, 6)
 py27 = sys.version_info >= (2, 7)
 jython = sys.platform.startswith('java')
 win32 = sys.platform.startswith('win')

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(name='Mako',
       tests_require=['pytest', 'mock'],
       cmdclass={'test': PyTest},
       zip_safe=False,
+      python_requires='>=2.6',
       install_requires=install_requires,
       extras_require={},
       entry_points="""

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,7 +1,7 @@
 from mako.template import Template
 import unittest
 import os
-from mako.compat import py3k, py26, py33
+from mako.compat import py3k, py33
 from mako import compat
 from mako.util import update_wrapper
 import re
@@ -119,9 +119,6 @@ def requires_python_3(fn):
 
 def requires_python_2(fn):
     return skip_if(lambda: py3k, "Requires Python 2.xx")(fn)
-
-def requires_python_26_or_greater(fn):
-    return skip_if(lambda: not py26, "Requires Python 2.6 or greater")(fn)
 
 def requires_pygments_14(fn):
     try:

--- a/test/test_ast.py
+++ b/test/test_ast.py
@@ -1,8 +1,7 @@
 import unittest
 
 from mako import ast, exceptions, pyparser, util, compat
-from test import eq_, requires_python_2, requires_python_3, \
-            requires_python_26_or_greater
+from test import eq_, requires_python_2, requires_python_3
 
 exception_kwargs = {
     'source': '',
@@ -223,7 +222,6 @@ t2 = lambda (x,y):(x+5, y+4)
         eq_(parsed.declared_identifiers, set(['t1', 't2']))
         eq_(parsed.undeclared_identifiers, set())
 
-    @requires_python_26_or_greater
     def test_locate_identifiers_16(self):
         code = """
 try:
@@ -234,7 +232,6 @@ except Exception as e:
         parsed = ast.PythonCode(code, **exception_kwargs)
         eq_(parsed.undeclared_identifiers, set(['x', 'y', 'Exception']))
 
-    @requires_python_26_or_greater
     def test_locate_identifiers_17(self):
         code = """
 try:

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -10,8 +10,7 @@ import os
 from test.util import flatten_result, result_lines
 from mako.compat import u
 from test import TemplateTest, eq_, template_base, module_base, \
-    requires_python_26_or_greater, assert_raises, assert_raises_message, \
-    requires_python_2
+    assert_raises, assert_raises_message, requires_python_2
 import unittest
 
 class ctx(object):
@@ -910,7 +909,6 @@ class ControlTest(TemplateTest):
             filters=lambda s:s.strip()
         )
 
-    @requires_python_26_or_greater
     def test_blank_control_8(self):
         self._do_memory_test(
             """
@@ -1009,7 +1007,6 @@ class ControlTest(TemplateTest):
             filters=lambda s:s.strip()
         )
 
-    @requires_python_26_or_greater
     def test_commented_blank_control_8(self):
         self._do_memory_test(
             """

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
 minversion=1.8.dev1
-envlist = py{26,27,34,35}
+envlist = py{26,27,34,35,36}
 
 [testenv]
 cov_args=--cov=mako --cov-report term --cov-report xml


### PR DESCRIPTION
Includes PR https://github.com/zzzeek/mako/pull/26 so [Travis CI passes](https://travis-ci.org/hugovk/mako/builds/329346809). The last two commits are unique to this PR.

---

Since Mako 1.0.0, Python 2.6 has been the minimum supported version:

> [general] Compatibility changes; in order to modernize the codebase, Mako is now dropping support for Python 2.4 and Python 2.5 altogether. The source base is now targeted at Python 2.6 and forwards.

http://docs.makotemplates.org/en/latest/changelog.html#change-b602a175c0ec26eaa4f42962d23cca96

This removes redundant code only relevant to Python 2.5 or earlier.

It also adds `python_requires` to setup.py, so pip won't install this version on Python 2.5 or earlier. For people with older versions, pip will install the next Mako version down.

Are all Python 3.x versions supported? If not, I'll add those to `python_requires` as well.